### PR TITLE
Add rate limiting to proxy routes

### DIFF
--- a/api/strings.go
+++ b/api/strings.go
@@ -22,8 +22,8 @@ func IsResourcePath(path string) bool {
 	return re.MatchString(path)
 }
 
-// Returns true if the path is a collection path like /api/shows (as opposed to 
-// /api/shows/2). It first checks if the path is a resource path to avoid 
+// Returns true if the path is a collection path like /api/shows (as opposed to
+// /api/shows/2). It first checks if the path is a resource path to avoid
 // overlap.
 func IsCollectionPath(path string) bool {
 	if IsResourcePath(path) {

--- a/api/strings_test.go
+++ b/api/strings_test.go
@@ -54,7 +54,7 @@ func TestIsNotCollectionPath(t *testing.T) {
 	}
 }
 
-// Checks various path formats to verify correct extraction of the collection 
+// Checks various path formats to verify correct extraction of the collection
 // name.
 func TestGetCollectionName(t *testing.T) {
 	s := []string{

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -59,14 +59,14 @@ func (c *Cache) Get(key string) ([]byte, bool) {
 	return x, y
 }
 
-// Set adds a new key-value pair to the cache with a time-to-live determined by 
+// Set adds a new key-value pair to the cache with a time-to-live determined by
 // getTTL(key) (defined below). Returns true if set was successful.
 // If setting to a key that already exists, the value is updated and the TTL is
 // reset (done by the theine library).
 func (c *Cache) Set(key string, value []byte) bool {
 	tick := time.Now()
-	// Theine supports setting entries with a TTL. 
-	// The '1' argument is for cost (weight) of the entry, used for cache 
+	// Theine supports setting entries with a TTL.
+	// The '1' argument is for cost (weight) of the entry, used for cache
 	// eviction strategies. We don't use it here, so it's set to 1 for all
 	// entries.
 	res := c.tcache.SetWithTTL(key, value, 1, getTTL(key))
@@ -74,7 +74,7 @@ func (c *Cache) Set(key string, value []byte) bool {
 	return res
 }
 
-// MakeCacheKey uses request info to build a consistent cache key. If the path 
+// MakeCacheKey uses request info to build a consistent cache key. If the path
 // is a "collection path," it appends the query parameters.
 func (c *Cache) MakeCacheKey(req *http.Request) string {
 	result := req.URL.Path
@@ -86,14 +86,14 @@ func (c *Cache) MakeCacheKey(req *http.Request) string {
 	// return potentially old data).
 	if api.IsCollectionPath(result) {
 		// Copy the query to avoid mutating the original.
-        q := req.URL.Query()
-        q.Del("forceRefresh") // Remove the param from the key
+		q := req.URL.Query()
+		q.Del("forceRefresh") // Remove the param from the key
 
 		// Encode the query parameters and append them to the path.
-        encoded := q.Encode()
-        if encoded != "" {
-            result += "?" + encoded
-        }
+		encoded := q.Encode()
+		if encoded != "" {
+			result += "?" + encoded
+		}
 	}
 	return result
 }
@@ -123,8 +123,8 @@ func getTTL(key string) time.Duration {
 // This is called when a collection item is removed due to expiration.
 func (c *Cache) evictCollection(name string) {
 	tick := time.Now()
-	// Range over every key in the cache. If the key belongs to the same 
-	// collection name, delete that entry. This is done concurrently via a 
+	// Range over every key in the cache. If the key belongs to the same
+	// collection name, delete that entry. This is done concurrently via a
 	// goroutine (go keyword).
 	c.tcache.Range(func(k string, v []byte) bool {
 		if api.GetCollectionName(k) == name {

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 	http.Handle("GET /api/", rateLimiter.Middleware(proxy))
 	http.Handle("GET /images/", rateLimiter.Middleware(proxy))
 
-	// SSE Endpoint. Is rate limiting necessary for SSE?
+	// SSE Endpoint.
 	http.HandleFunc("/spin-events", rateLimiter.MiddlewareFunc(spinEventsHandler))
 
 	// POST route to trigger an internal GET request for /api/spins to force a

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	proxy := proxy.NewReverseProxy(tokenEnvVarName, parsedURL)
 
 	// Normal proxy routes: /api/ and /images/
-	// Register HTTP handlers so that any GET requests to /api/ or /images/ go 
+	// Register HTTP handlers so that any GET requests to /api/ or /images/ go
 	// through our custom reverse proxy (the proxy we created above).
 	http.Handle("GET /api/", proxy)
 	http.Handle("GET /images/", proxy)
@@ -40,38 +40,38 @@ func main() {
 	// (In the future: may consider adding authentication to this route
 	// to prevent unauthorized access and abuse.)
 	http.HandleFunc("/trigger/spins", func(w http.ResponseWriter, r *http.Request) {
-        if r.Method != http.MethodPost {
-            http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
-            return
-        }
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
 		log.Println("trigger.spins")
 
-        // This request goes back into our own server, ensuring the proxy logic 
+		// This request goes back into our own server, ensuring the proxy logic
 		// is used. The key part is `?forceRefresh=1`.
-        resp, err := http.Get("http://localhost:8080/api/spins?forceRefresh=1")
-        if err != nil {
-            http.Error(w, "Failed to fetch spins: "+err.Error(), http.StatusInternalServerError)
-            return
-        }
-        defer resp.Body.Close()
-        // Read entire body so that the data flows through to our caching 
+		resp, err := http.Get("http://localhost:8080/api/spins?forceRefresh=1")
+		if err != nil {
+			http.Error(w, "Failed to fetch spins: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer resp.Body.Close()
+		// Read entire body so that the data flows through to our caching
 		// mechanism. TL;DR: this line is important because without it, the
 		// response body is not read and the cache is not updated! Reading the
 		// body is necessary to update the cache since the cache is updated in
 		// the proxy logic via `t.Cache.Set(key, data)` which is called when the
 		// response status is OK (handled in proxy.go).
-        _, _ = io.ReadAll(resp.Body)
+		_, _ = io.ReadAll(resp.Body)
 
 		BroadcastSpinMessage("new spin data")
 		log.Println("sse.broadcast", len(sseClients))
 
-        w.WriteHeader(http.StatusOK)
-        w.Write([]byte("Forced refresh of /api/spins. Cache updated."))
-    })
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Forced refresh of /api/spins. Cache updated."))
+	})
 
 	log.Println("spinitron-proxy started on port 8080")
 
-	// Listen on port 8080 for incoming HTTP requests. If there's an error, it 
+	// Listen on port 8080 for incoming HTTP requests. If there's an error, it
 	// returns a non-nil error (nil means no error).
 	// The `:=` operator is shorthand for declaring and initializing a variable
 	// in one line. It is equivalent to:
@@ -79,7 +79,7 @@ func main() {
 	//   err = http.ListenAndServe(":8080", nil)
 	err := http.ListenAndServe(":8080", nil)
 
-	// If ListenAndServe returns an error, panic is called to log it and exit 
+	// If ListenAndServe returns an error, panic is called to log it and exit
 	// the program.
 	panic(err)
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -30,28 +30,28 @@ type TransportWithCache struct {
 func (t *TransportWithCache) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// Check if the request has ?forceRefresh=1 to skip cache retrieval
-    forceRefresh := (req.URL.Query().Get("forceRefresh") == "1")
+	forceRefresh := (req.URL.Query().Get("forceRefresh") == "1")
 
 	// Generate a cache key based on the incoming HTTP request.
 	key := t.Cache.MakeCacheKey(req)
 
 	// If forceRefresh is NOT set, try retrieving from the cache as normal.
-    if !forceRefresh {
-		// Attempt to retrieve the response from the cache (e.g. if it was 
-		// cached before). The second return value is a boolean indicating 
+	if !forceRefresh {
+		// Attempt to retrieve the response from the cache (e.g. if it was
+		// cached before). The second return value is a boolean indicating
 		// whether the key was found in the cache.
-        value, found := t.Cache.Get(key)
-        if found {
-            // Construct a new response with the cached data.
-            resp := &http.Response{
-                StatusCode: http.StatusOK,
-                Header:     make(http.Header),
-                Body:       io.NopCloser(bytes.NewReader(value)),
-            }
-            resp.Header.Set("Content-Type", "application/json")
-            return resp, nil // `nil` means no error occurred.
-        }
-    } else {
+		value, found := t.Cache.Get(key)
+		if found {
+			// Construct a new response with the cached data.
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(bytes.NewReader(value)),
+			}
+			resp.Header.Set("Content-Type", "application/json")
+			return resp, nil // `nil` means no error occurred.
+		}
+	} else {
 		// If forceRefresh is set, log that we're skipping the cache.
 		log.Println("cache.skip", key, "(forceRefresh)")
 	}
@@ -85,15 +85,15 @@ func (t *TransportWithCache) RoundTrip(req *http.Request) (*http.Response, error
 	log.Println("request.made", time.Since(tick), key)
 
 	// Even if forceRefresh was set, we still store the new data in the cache,
-    // so that subsequent requests without forceRefresh can use the updated 
+	// so that subsequent requests without forceRefresh can use the updated
 	// data.
-    t.Cache.Set(key, data)
+	t.Cache.Set(key, data)
 
-    // Return the fresh response to the client.
+	// Return the fresh response to the client.
 	return resp, err
 }
 
-// NewReverseProxy creates a reverse proxy client to forward requests to the 
+// NewReverseProxy creates a reverse proxy client to forward requests to the
 // target (Spinitron API) URL.
 // It also sets up headers for authentication and configures caching.
 func NewReverseProxy(tokenEnvVarName string, target *url.URL) *httputil.ReverseProxy {
@@ -126,7 +126,7 @@ func NewReverseProxy(tokenEnvVarName string, target *url.URL) *httputil.ReverseP
 		req.Header.Set("Authorization", "Bearer "+t)
 		// Force the request to accept JSON.
 		req.Header.Set("accept", "application/json")
-		
+
 		// Set the Host header to the target host
 		req.Host = pubDomain
 		req.Header.Set("X-Forwarded-Host", pubDomain)
@@ -137,7 +137,7 @@ func NewReverseProxy(tokenEnvVarName string, target *url.URL) *httputil.ReverseP
 	c := &cache.Cache{}
 	c.Init()
 
-	// Override the proxy's default (from httputil.ReverseProxy) transport with 
+	// Override the proxy's default (from httputil.ReverseProxy) transport with
 	// our custom caching transport.
 	rp.Transport = &TransportWithCache{
 		Transport: http.DefaultTransport,

--- a/ratelimiter/ratelimiter.go
+++ b/ratelimiter/ratelimiter.go
@@ -1,0 +1,118 @@
+package ratelimiter
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type RateLimiter struct {
+	// The maximum number of requests allowed in the given duration.
+	MaxRequests int
+	// The duration in which the maximum number of requests is allowed.
+	Duration time.Duration
+	// The map to store the number of requests made by an IP address.
+	VisitorMap map[string]int
+	// The mutex to synchronize access to the VisitorMap.
+	VisitorMapMux sync.Mutex
+}
+
+// NewRateLimiter creates a new RateLimiter with the given maximum number of
+// requests and duration.
+func NewRateLimiter(maxRequests int, duration time.Duration) *RateLimiter {
+	return &RateLimiter{
+		MaxRequests: maxRequests,
+		Duration:    duration,
+		VisitorMap:  make(map[string]int),
+	}
+}
+
+// Allow checks if the given IP address is allowed to make a request based on
+// the rate limiting rules (that is, the maximum number of requests allowed in
+// the given duration under a given IP and path).
+func (rl *RateLimiter) Allow(r *http.Request) bool {
+	rl.VisitorMapMux.Lock()
+	defer rl.VisitorMapMux.Unlock()
+
+	// Generate the request key based on the IP address and the request path.
+	key := rl.MakeRequestKey(r)
+
+	// Get the current count of requests made by the IP address.
+	count, ok := rl.VisitorMap[key]
+	if !ok {
+		// If the IP address is not in the map, initialize it with 1 request.
+		rl.VisitorMap[key] = 1
+		return true
+	}
+
+	// If the count exceeds the maximum number of requests, return false.
+	if count >= rl.MaxRequests {
+		return false
+	}
+
+	// Increment the count of requests made by the IP address.
+	rl.VisitorMap[key]++
+
+	// Launch a goroutine to decrement the count after the duration has passed.
+	go func() {
+		time.Sleep(rl.Duration)
+		rl.Subtract(key)
+	}()
+
+	return true
+}
+
+// The Subtract function is used to decrement the count of requests made by an
+// IP address, normally called after the request has been processed. It runs
+// in a separate goroutine to avoid blocking the request processing.
+func (rl *RateLimiter) Subtract(key string) {
+	rl.VisitorMapMux.Lock()
+	defer rl.VisitorMapMux.Unlock()
+
+	// Decrement the count of requests made under the given key (IP + path).
+	rl.VisitorMap[key]--
+}
+
+// Generates the request key based on the IP address and the request path.
+func (rl *RateLimiter) MakeRequestKey(r *http.Request) string {
+	// Strip the port number from the IP address.
+	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
+	return ip + r.URL.Path
+}
+
+// The middleware function that wraps the handler and enforces rate limiting.
+// If the request is denied, it returns a 429 Too Many Requests status code.
+// Additionally, it logs the IP address and path of the request that was denied.
+func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !rl.Allow(r) {
+			// Write how much time the client has to wait before making another request.
+			http.Header.Add(w.Header(), "Retry-After", rl.Duration.String())
+			// Return a 429 Too Many Requests status code.
+			http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+
+			log.Printf("Rate limit exceeded for %s on %s\n", r.RemoteAddr, r.URL.Path)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// This middleware function is similar to the previous one, but it's meant
+// for use with the http.HandlerFunc type instead of http.Handler.
+// It enforces rate limiting and returns a 429 Too Many Requests status code,
+// along with logging the IP address and path of the request that was denied.
+func (rl *RateLimiter) MiddlewareFunc(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !rl.Allow(r) {
+			http.Header.Add(w.Header(), "Retry-After", rl.Duration.String())
+			http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+
+			log.Printf("Rate limit exceeded for %s on %s\n", r.RemoteAddr, r.URL.Path)
+			return
+		}
+		next(w, r)
+	}
+}

--- a/sse.go
+++ b/sse.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-    sseClients  []chan string
-    sseClientsM sync.Mutex // to synchronize access to sseClients
+	sseClients  []chan string
+	sseClientsM sync.Mutex // to synchronize access to sseClients
 )
 
 // spinEventsHandler is an HTTP handler that streams server-sent events (SSE) to
@@ -16,61 +16,61 @@ var (
 // the channel to the sseClients array. It then sends messages to the client
 // when they are available.
 func spinEventsHandler(w http.ResponseWriter, r *http.Request) {
-    // Check if the client supports server-sent events via the http.Flusher
+	// Check if the client supports server-sent events via the http.Flusher
 	// interface. If it doesn't, return an error.
 	flusher, ok := w.(http.Flusher)
-    if !ok {
-        http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
-        return
-    }
+	if !ok {
+		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+		return
+	}
 
-    // Create a channel for this client to receive messages
-    msgChan := make(chan string, 1)
+	// Create a channel for this client to receive messages
+	msgChan := make(chan string, 1)
 
-    // Lock, modify slice, unlock
-    sseClientsM.Lock()
-    sseClients = append(sseClients, msgChan)
+	// Lock, modify slice, unlock
+	sseClientsM.Lock()
+	sseClients = append(sseClients, msgChan)
 	log.Println("sse.connect", len(sseClients))
-    sseClientsM.Unlock()
-    
-    // Clean up when the client disconnects: remove the channel from the array
-    // and close the channel.
-    defer func() {
-        sseClientsM.Lock()
-        defer sseClientsM.Unlock()
-        for i, c := range sseClients {
-            if c == msgChan {
+	sseClientsM.Unlock()
+
+	// Clean up when the client disconnects: remove the channel from the array
+	// and close the channel.
+	defer func() {
+		sseClientsM.Lock()
+		defer sseClientsM.Unlock()
+		for i, c := range sseClients {
+			if c == msgChan {
 				// Slice the client out of the array
-                sseClients = append(sseClients[:i], sseClients[i+1:]...)
+				sseClients = append(sseClients[:i], sseClients[i+1:]...)
 				log.Println("sse.disconnect", len(sseClients))
-                break
-            }
-        }
-        close(msgChan)
-    }()
+				break
+			}
+		}
+		close(msgChan)
+	}()
 
-    w.Header().Set("Content-Type", "text/event-stream")
-    w.Header().Set("Cache-Control", "no-cache")
-    w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
 
-    for {
-        select {
-        case <-r.Context().Done():
-            // Client closed connection
-            return
-        case msg := <-msgChan:
-            // Send SSE message
-            _, _ = w.Write([]byte(msg + "\n\n"))
-            flusher.Flush()
-        }
-    }
+	for {
+		select {
+		case <-r.Context().Done():
+			// Client closed connection
+			return
+		case msg := <-msgChan:
+			// Send SSE message
+			_, _ = w.Write([]byte(msg + "\n\n"))
+			flusher.Flush()
+		}
+	}
 }
 
 // Send `msg` to all SSE clients
 func BroadcastSpinMessage(msg string) {
-    sseClientsM.Lock()
-    defer sseClientsM.Unlock()
-    for _, c := range sseClients {
-        c <- "data: "+msg
-    }
+	sseClientsM.Lock()
+	defer sseClientsM.Unlock()
+	for _, c := range sseClients {
+		c <- "data: " + msg
+	}
 }


### PR DESCRIPTION
This PR adds a package, ratelimiter, which handles rate limiting logic for proxy routes. It uses a mutex lock to avoid inconsistencies and clean-up is done inside goroutines, avoiding disruptions after DoS/DDoS attacks.

Currently, every route is being protected using a limit of 60 requests per minute (1/sec).